### PR TITLE
add ES3 fallbacks for Array.isArray and Object.keys

### DIFF
--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -112,9 +112,9 @@ foreign import isUndefined
 
 foreign import isArray
   """
-  function isArray(value) {
-    return Array.isArray(value);
-  }
+  var isArray = Array.isArray || function(value) {
+    return Object.prototype.toString.call(value) === '[object Array]';
+  };
   """ :: Foreign -> Boolean
 
 readString :: Foreign -> F String

--- a/src/Data/Foreign/Keys.purs
+++ b/src/Data/Foreign/Keys.purs
@@ -8,9 +8,15 @@ import Data.Function
 
 foreign import unsafeKeys
   """
-  function unsafeKeys(value) {
-    return Object.keys(value);
-  }
+  var unsafeKeys = Object.keys || function(value) {
+    var keys = [];
+    for (var prop in value) {
+      if (Object.prototype.hasOwnProperty.call(value, prop)) {
+        keys.push(prop);
+      }
+    }
+    return keys;
+  };
   """ :: Foreign -> [String]
 
 keys :: Foreign -> F [String]


### PR DESCRIPTION
The [MDN polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) is unappealing:

``` javascript
// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
if (!Object.keys) {
  Object.keys = (function() {
    'use strict';
    var hasOwnProperty = Object.prototype.hasOwnProperty,
        hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
        dontEnums = [
          'toString',
          'toLocaleString',
          'valueOf',
          'hasOwnProperty',
          'isPrototypeOf',
          'propertyIsEnumerable',
          'constructor'
        ],
        dontEnumsLength = dontEnums.length;

    return function(obj) {
      if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
        throw new TypeError('Object.keys called on non-object');
      }

      var result = [], prop, i;

      for (prop in obj) {
        if (hasOwnProperty.call(obj, prop)) {
          result.push(prop);
        }
      }

      if (hasDontEnumBug) {
        for (i = 0; i < dontEnumsLength; i++) {
          if (hasOwnProperty.call(obj, dontEnums[i])) {
            result.push(dontEnums[i]);
          }
        }
      }
      return result;
    };
  }());
}
```

I opted for a simpler version which doesn't make allowances for a bug in old versions of Internet Explorer. I'm happy to switch to the foolproof (but ugly!) fallback if desired.

Also, this is interesting:

> In ES5, if the argument to this method is not an object (a primitive), then it will cause a `TypeError`. In ES6, a non-object argument will be coerced to an object.
> 
> ``` javascript
> > Object.keys("foo")
> TypeError: "foo" is not an object // ES5 code
> 
> > Object.keys("foo")
> ["0", "1", "2"]
> ```

What's the desired behaviour in our case? We should avoid `Object.keys` entirely to avoid generating code with environment-dependent semantics.
