### PR TITLE
simplify null guard

### DIFF
--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -25,11 +25,7 @@ class Index i where
 foreign import unsafeReadPropImpl
   """
   function unsafeReadPropImpl(f, s, key, value) {
-    if (value && typeof value === 'object') {
-      return s(value[key]);
-    } else {
-      return f;
-    }
+    return value == null ? f : s(value[key]);
   }
   """ :: forall r k. Fn4 r (Foreign -> r) k Foreign (F Foreign)
 


### PR DESCRIPTION
We could use `!== null` here instead, since `typeof undefined` is not `'object'`, but as a general rule I avoid differentiating between null and undefined.
