### PR TITLE
Add Eq instance for ForeignError

### DIFF
--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -40,6 +40,14 @@ instance showForeignError :: Show ForeignError where
   show (ErrorAtProperty prop e) = "Error at property " ++ show prop ++ ": " ++ show e
   show (JSONError s) = "JSON error: " ++ s
 
+instance eqForeignError :: Eq ForeignError where
+  (==) (TypeMismatch a b) (TypeMismatch a' b') = a == a' && b == b'
+  (==) (ErrorAtIndex i e) (ErrorAtIndex i' e') = i == i' && e == e'
+  (==) (ErrorAtProperty p e) (ErrorAtProperty p' e') = p == p' && e == e'
+  (==) (JSONError s) (JSONError s') = s == s'
+  (==) _ _ = false
+  (/=) a b = not (a == b)
+
 type F = Either ForeignError
 
 foreign import parseJSONImpl


### PR DESCRIPTION
The use case is uncommon here, but this comes up a lot in testing. If
you're testing an IsForeign instance, you'd want to assert equality on F
which is Either ForeignError a.
