### PR TITLE
Add Unit instance

### DIFF
--- a/docs/Module.md
+++ b/docs/Module.md
@@ -204,6 +204,13 @@ instance numberIsForeign :: IsForeign Number
 ```
 
 
+#### `unitIsForeign`
+
+``` purescript
+instance unitIsForeign :: IsForeign Unit
+```
+
+
 #### `arrayIsForeign`
 
 ``` purescript

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -39,6 +39,9 @@ instance booleanIsForeign :: IsForeign Boolean where
 instance numberIsForeign :: IsForeign Number where
   read = readNumber
 
+instance unitIsForeign :: IsForeign Unit where
+  read _ = return unit
+
 instance arrayIsForeign :: (IsForeign a) => IsForeign [a] where
   read value = readArray value >>= readElements
     where


### PR DESCRIPTION
Just returning `unit` and not actually attempting to read/parse anything here makes sense I think?