### PR TITLE
Add IsForeign instances for Int and Char

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "purescript-either": "^0.2.0",
     "purescript-integers": "^0.2.0",
     "purescript-arrays": "^0.4.0",
-    "purescript-functions": "^0.1.0"
+    "purescript-functions": "^0.1.0",
+    "purescript-strings": "~0.5.3"
   },
   "devDependencies": {
     "purescript-console": "^0.1.0"

--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -17,14 +17,17 @@ module Data.Foreign
   , readString
   , readBoolean
   , readNumber
+  , readInt
   , readArray
   ) where
 
 import Prelude
 
-import Data.Either (Either(..))
+import Data.Either (Either(..), either)
+import Data.Maybe (maybe)
 import Data.Function (Fn3(), runFn3)
 import Data.Int ()
+import qualified Data.Int as Int
 
 -- | A type for _foreign data_.
 -- |
@@ -108,6 +111,16 @@ readBoolean = unsafeReadTagged "Boolean"
 -- | Attempt to coerce a foreign value to a `Number`.
 readNumber :: Foreign -> F Number
 readNumber = unsafeReadTagged "Number"
+
+-- | Attempt to coerce a foreign value to an `Int`.
+readInt :: Foreign -> F Int
+readInt value = either (const error) fromNumber (readNumber value)
+  where
+  fromNumber :: Number -> F Int
+  fromNumber = maybe error pure <<< Int.fromNumber
+
+  error :: F Int
+  error = Left $ TypeMismatch "Int" (tagOf value)
 
 -- | Attempt to coerce a foreign value to an array.
 readArray :: Foreign -> F (Array Foreign)

--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -15,6 +15,7 @@ module Data.Foreign
   , isUndefined
   , isArray
   , readString
+  , readChar
   , readBoolean
   , readNumber
   , readInt
@@ -28,6 +29,7 @@ import Data.Maybe (maybe)
 import Data.Function (Fn3(), runFn3)
 import Data.Int ()
 import qualified Data.Int as Int
+import Data.String (toChar)
 
 -- | A type for _foreign data_.
 -- |
@@ -103,6 +105,16 @@ foreign import isArray :: Foreign -> Boolean
 -- | Attempt to coerce a foreign value to a `String`.
 readString :: Foreign -> F String
 readString = unsafeReadTagged "String"
+
+-- | Attempt to coerce a foreign value to a `Char`.
+readChar :: Foreign -> F Char
+readChar value = either (const error) fromString (readString value)
+  where
+  fromString :: String -> F Char
+  fromString = maybe error pure <<< toChar
+
+  error :: F Char
+  error = Left $ TypeMismatch "Char" (tagOf value)
 
 -- | Attempt to coerce a foreign value to a `Boolean`.
 readBoolean :: Foreign -> F Boolean

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -41,6 +41,9 @@ instance booleanIsForeign :: IsForeign Boolean where
 instance numberIsForeign :: IsForeign Number where
   read = readNumber
 
+instance intIsForeign :: IsForeign Int where
+  read = readInt
+
 instance arrayIsForeign :: (IsForeign a) => IsForeign (Array a) where
   read value = readArray value >>= readElements
     where

--- a/src/Data/Foreign/Class.purs
+++ b/src/Data/Foreign/Class.purs
@@ -35,6 +35,9 @@ instance foreignIsForeign :: IsForeign Foreign where
 instance stringIsForeign :: IsForeign String where
   read = readString
 
+instance charIsForeign :: IsForeign Char where
+  read = readChar
+
 instance booleanIsForeign :: IsForeign Boolean where
   read = readBoolean
 


### PR DESCRIPTION
I think the code is slightly verbose for these as I wanted to never show errors from the underlying `readString` and `readNumber`.