### PR TITLE
Add a class to create Foreign types

### DIFF
--- a/examples/JSONSimpleTypes.purs
+++ b/examples/JSONSimpleTypes.purs
@@ -3,10 +3,10 @@ module Example.JSONSimpleTypes where
 import Prelude
 
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 
-import Data.Foreign (F)
-import Data.Foreign.Class (readJSON)
+import Data.Foreign (F, unsafeFromForeign)
+import Data.Foreign.Class (readJSON, write)
 
 -- Parsing of the simple JSON String, Number and Boolean types is provided
 -- out of the box.
@@ -15,3 +15,6 @@ main = do
   logShow $ readJSON "\"a JSON string\"" :: F String
   logShow $ readJSON "42" :: F Number
   logShow $ readJSON "true" :: F Boolean
+  log $ unsafeFromForeign $ write "a JSON string"
+  log $ unsafeFromForeign $ write 42.0
+  log $ unsafeFromForeign $ write true

--- a/examples/MaybeNullable.purs
+++ b/examples/MaybeNullable.purs
@@ -3,11 +3,12 @@ module Example.MaybeNullable where
 import Prelude
 
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 
-import Data.Foreign (F)
-import Data.Foreign.Class (readJSON)
-import Data.Foreign.Null (Null, unNull)
+import Data.Foreign (F, unsafeFromForeign)
+import Data.Foreign.Class (readJSON, write)
+import Data.Foreign.Null (Null(..), unNull)
+import Data.Maybe (Maybe(..))
 
 -- Parsing values that are allowed to null or undefined is possible by
 -- using Maybe types.
@@ -15,3 +16,5 @@ main :: Eff (console :: CONSOLE) Unit
 main = do
   logShow $ unNull <$> readJSON "null" :: F (Null Boolean)
   logShow $ unNull <$> readJSON "true" :: F (Null Boolean)
+  log $ unsafeFromForeign $ write $ Null Nothing :: Null Boolean
+  log $ unsafeFromForeign $ write $ Null $ Just true

--- a/examples/Objects.purs
+++ b/examples/Objects.purs
@@ -3,10 +3,10 @@ module Example.Objects where
 import Prelude
 
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 
-import Data.Foreign (F)
-import Data.Foreign.Class (class IsForeign, readJSON, readProp)
+import Data.Foreign (F, writeObject, unsafeFromForeign)
+import Data.Foreign.Class (class AsForeign, class IsForeign, (.=), readJSON, readProp, write)
 
 -- | To parse objects of a particular type, we need to define some helper
 --   data types as making class instances for records is not possible.
@@ -14,6 +14,11 @@ data Point = Point { x :: Number, y :: Number }
 
 instance showPoint :: Show Point where
   show (Point o) = "(Point { x: " <> show o.x <> ", y: " <> show o.y <> " })"
+
+instance pointAsForeign :: AsForeign Point where
+  write (Point o) = writeObject [ "x" .= o.x
+                                , "y" .= o.y
+                                ]
 
 -- | The IsForeign implementations for these types are basically boilerplate,
 --   type inference takes care of most of the work so we don't have to
@@ -27,3 +32,4 @@ instance pointIsForeign :: IsForeign Point where
 main :: Eff (console :: CONSOLE) Unit
 main = do
   logShow $ readJSON """{ "x": 1, "y": 2 }""" :: F Point
+  log $ unsafeFromForeign $ write $ Point { x: 1.0, y: 2.0 }

--- a/src/Data/Foreign.js
+++ b/src/Data/Foreign.js
@@ -40,3 +40,11 @@ exports.isUndefined = function (value) {
 exports.isArray = Array.isArray || function (value) {
   return Object.prototype.toString.call(value) === "[object Array]";
 };
+
+exports.writeObject = function (fields) {
+  var record = {};
+  for (var i in fields) {
+    record[fields[i].key] = fields[i].value;
+  }
+  return record;
+};

--- a/src/Data/Foreign.js
+++ b/src/Data/Foreign.js
@@ -43,7 +43,7 @@ exports.isArray = Array.isArray || function (value) {
 
 exports.writeObject = function (fields) {
   var record = {};
-  for (var i in fields) {
+  for (var i = 0; i < fields.length; i++) {
     record[fields[i].key] = fields[i].value;
   }
   return record;

--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -4,6 +4,7 @@
 module Data.Foreign
   ( Foreign()
   , ForeignError(..)
+  , Prop(..)
   , F()
   , parseJSON
   , toForeign
@@ -20,6 +21,7 @@ module Data.Foreign
   , readNumber
   , readInt
   , readArray
+  , writeObject
   ) where
 
 import Prelude
@@ -137,3 +139,7 @@ readInt value = either (const error) fromNumber (readNumber value)
 readArray :: Foreign -> F (Array Foreign)
 readArray value | isArray value = pure $ unsafeFromForeign value
 readArray value = Left (TypeMismatch "array" (tagOf value))
+
+newtype Prop = Prop { key :: String, value :: Foreign }
+
+foreign import writeObject :: Array Prop -> Foreign

--- a/src/Data/Foreign/Null.js
+++ b/src/Data/Foreign/Null.js
@@ -1,0 +1,6 @@
+/* global exports */
+"use strict";
+
+// module Data.Foreign.Null
+
+exports.writeNull = null;

--- a/src/Data/Foreign/Null.purs
+++ b/src/Data/Foreign/Null.purs
@@ -20,3 +20,5 @@ unNull (Null m) = m
 readNull :: forall a. (Foreign -> F a) -> Foreign -> F (Null a)
 readNull _ value | isNull value = pure (Null Nothing)
 readNull f value = Null <<< Just <$> f value
+
+foreign import writeNull :: Foreign

--- a/src/Data/Foreign/Undefined.js
+++ b/src/Data/Foreign/Undefined.js
@@ -1,0 +1,6 @@
+/* global exports */
+"use strict";
+
+// module Data.Foreign.Undefined
+
+exports.writeUndefined = undefined;

--- a/src/Data/Foreign/Undefined.purs
+++ b/src/Data/Foreign/Undefined.purs
@@ -20,3 +20,5 @@ unUndefined (Undefined m) = m
 readUndefined :: forall a. (Foreign -> F a) -> Foreign -> F (Undefined a)
 readUndefined _ value | isUndefined value = pure (Undefined Nothing)
 readUndefined f value = Undefined <<< Just <$> f value
+
+foreign import writeUndefined :: Foreign


### PR DESCRIPTION
Allows specifying the exact format of JavaScript values for FFI code:

    data A = A (Maybe String) (Maybe String)

    instance aAsForeign :: AsForeign A where
      write (A x y) = writeObject [ "x" .= Null x
                                  , "y" .= Null y
                                  ]

    foreign import data B :: *

    foreign import convertImpl :: Foreign -> B

    convert :: A -> B
    convert = convertImpl <<< asForeign

Fixes #31