### PR TITLE
Clarify Foreign type doc

### DIFF
--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -41,8 +41,14 @@ import Data.String (toChar)
 -- | A type for _foreign data_.
 -- |
 -- | Foreign data is data from any external _unknown_ or _unreliable_
--- | source, for which it cannot be guaranteed that the runtime representation
--- | conforms to that of any particular type.
+-- | source for which it cannot be guaranteed that the runtime representation
+-- | conforms to that of any particular type. A common example of foreign data is
+-- | the value returned by a JavaScript function provided by a third-party JavaScript
+-- | library which is called in the JavaScript defined in a PS FFI file.
+-- | Foreign data is *not* a JSON string, though a JSON string can be parsed
+-- | to become foreign data. The `parseJSON` function will perform this parse to
+-- | create a `Foreign` type, while the `readJSON` function will, going further,
+-- | read it to produce the matching PureScript type.
 -- |
 -- | Suitable applications of `Foreign` are
 -- |


### PR DESCRIPTION
I had a hard time understanding what a Foreign type was. It's like my other unanswerable question: "What is null?"

I thought a Foreign type was a JSON string I got from an API, but it's not quite true. A Foreign type is an "in-memory data structure", so a JSON string needs to be parsed before used by this library.