### PR TITLE
Derive `Newtype` instance for `Prop`

### DIFF
--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -36,6 +36,7 @@ import Data.Int as Int
 import Data.List.NonEmpty (NonEmptyList)
 import Data.List.NonEmpty as NEL
 import Data.Maybe (maybe)
+import Data.Newtype (class Newtype)
 import Data.String (toChar)
 
 -- | A type for _foreign data_.
@@ -156,6 +157,8 @@ fail = throwError <<< NEL.singleton
 
 -- | A key/value pair for an object to be written as a `Foreign` value.
 newtype Prop = Prop { key :: String, value :: Foreign }
+
+derive instance newtypeProp :: Newtype Prop _
 
 -- | Constructs a JavaScript `Object` value (typed as `Foreign`) from an array
 -- | of `Prop`s.


### PR DESCRIPTION
This derives a `Newtype` instance for `Prop`.

I'm only really concerned with `Prop`, and didn't want to introduce any breaking changes to the other `newtype`s, but I'm happy to at least add `derived` instances for those if that's desirable.

I assume that the existing `unX` and `readX` functions can coexist, and would be marked for deprecation.