### PR TITLE
Add various instances for `NullOrUndefined`

### DIFF
--- a/src/Data/Foreign/Null.purs
+++ b/src/Data/Foreign/Null.purs
@@ -18,7 +18,7 @@ derive instance eqNull :: (Eq a) => Eq (Null a)
 derive instance ordNull :: (Ord a) => Ord (Null a)
 
 instance showNull :: (Show a) => Show (Null a) where
-  show x = "Null " <> show (unwrap x)
+  show x = "(Null " <> show (unwrap x) <> ")"
 
 -- | Unwrap a `Null` value
 unNull :: forall a. Null a -> Maybe a

--- a/src/Data/Foreign/Null.purs
+++ b/src/Data/Foreign/Null.purs
@@ -3,6 +3,7 @@ module Data.Foreign.Null where
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, unwrap)
 import Data.Foreign (F, Foreign, isNull)
 
 -- | A `newtype` wrapper whose `IsForeign` instance correctly handles
@@ -11,6 +12,13 @@ import Data.Foreign (F, Foreign, isNull)
 -- | Conceptually, this type represents values which may be `null`,
 -- | but not `undefined`.
 newtype Null a = Null (Maybe a)
+
+derive instance newtypeNull :: Newtype (Null a) _
+derive instance eqNull :: (Eq a) => Eq (Null a)
+derive instance ordNull :: (Ord a) => Ord (Null a)
+
+instance showNull :: (Show a) => Show (Null a) where
+  show x = "Null " <> show (unwrap x)
 
 -- | Unwrap a `Null` value
 unNull :: forall a. Null a -> Maybe a

--- a/src/Data/Foreign/NullOrUndefined.purs
+++ b/src/Data/Foreign/NullOrUndefined.purs
@@ -2,7 +2,6 @@ module Data.Foreign.NullOrUndefined where
 
 import Prelude
 
-import Data.Function (on)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Maybe (Maybe(..))
 import Data.Foreign (F, Foreign, isUndefined, isNull)

--- a/src/Data/Foreign/NullOrUndefined.purs
+++ b/src/Data/Foreign/NullOrUndefined.purs
@@ -2,6 +2,8 @@ module Data.Foreign.NullOrUndefined where
 
 import Prelude
 
+import Data.Function (on)
+import Data.Newtype (class Newtype, unwrap)
 import Data.Maybe (Maybe(..))
 import Data.Foreign (F, Foreign, isUndefined, isNull)
 
@@ -11,6 +13,13 @@ import Data.Foreign (F, Foreign, isUndefined, isNull)
 -- | Conceptually, this type represents values which may be `null`
 -- | or `undefined`.
 newtype NullOrUndefined a = NullOrUndefined (Maybe a)
+
+derive instance newtypeNullOrUndefined :: Newtype (NullOrUndefined a) _
+derive instance eqNullOrUndefined :: (Eq a) => Eq (NullOrUndefined a)
+derive instance ordNullOrUndefined :: (Ord a) => Ord (NullOrUndefined a)
+
+instance showNullOrUndefined :: (Show a) => Show (NullOrUndefined a) where
+  show x = "NullOrUndefined " <> show (unwrap x)
 
 -- | Unwrap a `NullOrUndefined` value
 unNullOrUndefined :: forall a. NullOrUndefined a -> Maybe a

--- a/src/Data/Foreign/NullOrUndefined.purs
+++ b/src/Data/Foreign/NullOrUndefined.purs
@@ -19,7 +19,7 @@ derive instance eqNullOrUndefined :: (Eq a) => Eq (NullOrUndefined a)
 derive instance ordNullOrUndefined :: (Ord a) => Ord (NullOrUndefined a)
 
 instance showNullOrUndefined :: (Show a) => Show (NullOrUndefined a) where
-  show x = "NullOrUndefined " <> show (unwrap x)
+  show x = "(NullOrUndefined " <> show (unwrap x) <> ")"
 
 -- | Unwrap a `NullOrUndefined` value
 unNullOrUndefined :: forall a. NullOrUndefined a -> Maybe a

--- a/src/Data/Foreign/Undefined.purs
+++ b/src/Data/Foreign/Undefined.purs
@@ -18,7 +18,7 @@ derive instance eqUndefined :: (Eq a) => Eq (Undefined a)
 derive instance ordUndefined :: (Ord a) => Ord (Undefined a)
 
 instance showUndefined :: (Show a) => Show (Undefined a) where
-  show x = "Undefined " <> show (unwrap x)
+  show x = "(Undefined " <> show (unwrap x) <> ")"
 
 -- | Unwrap an `Undefined` value
 unUndefined :: forall a. Undefined a -> Maybe a

--- a/src/Data/Foreign/Undefined.purs
+++ b/src/Data/Foreign/Undefined.purs
@@ -3,6 +3,7 @@ module Data.Foreign.Undefined where
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, unwrap)
 import Data.Foreign (F, Foreign, isUndefined)
 
 -- | A `newtype` wrapper whose `IsForeign` instance correctly handles
@@ -11,6 +12,13 @@ import Data.Foreign (F, Foreign, isUndefined)
 -- | Conceptually, this type represents values which may be `undefined`,
 -- | but not `null`.
 newtype Undefined a = Undefined (Maybe a)
+
+derive instance newtypeUndefined :: Newtype (Undefined a) _
+derive instance eqUndefined :: (Eq a) => Eq (Undefined a)
+derive instance ordUndefined :: (Ord a) => Ord (Undefined a)
+
+instance showUndefined :: (Show a) => Show (Undefined a) where
+  show x = "Undefined " <> show (unwrap x)
 
 -- | Unwrap an `Undefined` value
 unUndefined :: forall a. Undefined a -> Maybe a


### PR DESCRIPTION
Add various useful instances for `NullOrUndefined`, `Null` and `Undefined`, such as `Ord`, `Eq`, `Show` and `Newtype`.

Fixes #51