### PR TITLE
Add note explain why Except instead of Either

### DIFF
--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -81,6 +81,8 @@ renderForeignError (TypeMismatch exp act) = "Type mismatch: expected " <> exp <>
 
 -- | An error monad, used in this library to encode possible failures when
 -- | dealing with foreign data.
+-- | `Except e` was chosen instead of `Either e` because `Except`'s `Alt` instance
+-- | accumulates multiple errors, whereas `Either`'s preserves the last error.
 type F a = Except MultipleErrors a
 
 foreign import parseJSONImpl :: forall r. Fn3 (String -> r) (Foreign -> r) String r

--- a/src/Data/Foreign.purs
+++ b/src/Data/Foreign.purs
@@ -81,8 +81,9 @@ renderForeignError (TypeMismatch exp act) = "Type mismatch: expected " <> exp <>
 
 -- | An error monad, used in this library to encode possible failures when
 -- | dealing with foreign data.
--- | `Except e` was chosen instead of `Either e` because `Except`'s `Alt` instance
--- | accumulates multiple errors, whereas `Either`'s preserves the last error.
+-- |
+-- | The `Alt` instance for `Except` allows us to accumulate errors,
+-- | unlike `Either`, which preserves only the last error.
 type F a = Except MultipleErrors a
 
 foreign import parseJSONImpl :: forall r. Fn3 (String -> r) (Foreign -> r) String r


### PR DESCRIPTION
I've forever wondered what value is worth the price of putting `runExcept` everywhere. After asking, it seems like how they accumulate errors is the reason.