### PR TITLE
readProp and readIndex should handle "property does not exist" case

### DIFF
--- a/src/Data/Foreign/Index.js
+++ b/src/Data/Foreign/Index.js
@@ -1,18 +1,7 @@
 "use strict";
 
-exports.unsafeReadPropImpl = function (f, f2, s, key, value) {
-  if (value == null) {
-    // Fail with "not an object error"
-    return f;
-  } else {
-    if (key in value) {
-      return s(value[key]);
-    } else {
-      // Fail with "property does not
-      // exist or index does not existerror"
-      return f2;
-    }
-  };
+exports.unsafeReadPropImpl = function (f, s, key, value) {
+  return value == null ? f : s(value[key]);
 };
 
 exports.unsafeHasOwnProperty = function (prop, value) {

--- a/src/Data/Foreign/Index.js
+++ b/src/Data/Foreign/Index.js
@@ -5,10 +5,14 @@ exports.unsafeReadPropImpl = function (f, f2, s, key, value) {
     // Fail with "not an object error"
     return f;
   } else {
-    // Succeed or fail with "property does not
-    // exist or index does not existerror"
-    return (key in value) ? s(value[key]) : f2;
-  }
+    if (key in value) {
+      return s(value[key]);
+    } else {
+      // Fail with "property does not
+      // exist or index does not existerror"
+      return f2;
+    }
+  };
 };
 
 exports.unsafeHasOwnProperty = function (prop, value) {

--- a/src/Data/Foreign/Index.js
+++ b/src/Data/Foreign/Index.js
@@ -1,7 +1,18 @@
 "use strict";
 
-exports.unsafeReadPropImpl = function (f, s, key, value) {
-  return value == null ? f : s(value[key]);
+exports.unsafeReadPropImpl = function (f, f2, s, key, value) {
+  if (value == null) {
+    // Fail with "not an object error"
+    return f;
+  } else {
+    if (key in value) {
+      return s(value[key]);
+    } else {
+      // Fail with "property does not
+      // exist or index does not existerror"
+      return f2;
+    }
+  };
 };
 
 exports.unsafeHasOwnProperty = function (prop, value) {

--- a/src/Data/Foreign/Index.js
+++ b/src/Data/Foreign/Index.js
@@ -5,14 +5,10 @@ exports.unsafeReadPropImpl = function (f, f2, s, key, value) {
     // Fail with "not an object error"
     return f;
   } else {
-    if (key in value) {
-      return s(value[key]);
-    } else {
-      // Fail with "property does not
-      // exist or index does not existerror"
-      return f2;
-    }
-  };
+    // Succeed or fail with "property does not
+    // exist or index does not existerror"
+    return (key in value) ? s(value[key]) : f2;
+  }
 };
 
 exports.unsafeHasOwnProperty = function (prop, value) {

--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -53,8 +53,8 @@ readProp = unsafeReadProp
 -- | exist
 readProp' :: String -> Foreign -> F Foreign
 readProp' s f = do
-  case isNull f of
-    true -> fail $ ForeignError $ "Error reading property '" <> s <> "' from null value."
+  case (isNull f || isUndefined f) of
+    true -> fail $ ForeignError $ "Error reading property '" <> s <> "' from non-object."
     false -> do
       p <- readProp s f
       case hasProperty s f of
@@ -70,8 +70,8 @@ readIndex = unsafeReadProp
 -- | exist
 readIndex' :: Int -> Foreign -> F Foreign
 readIndex' s f = do
-  case isNull f of
-    true -> fail $ ForeignError $ "Error reading index " <> (show s) <> " from null value."
+  case (isNull f || isUndefined f) of
+    true -> fail $ ForeignError $ "Error reading index " <> (show s) <> " from non-object."
     false -> do
       p <- readIndex s f
       case hasProperty s f of

--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -16,7 +16,6 @@ module Data.Foreign.Index
   ) where
 
 import Prelude
-import AppPrelude (one)
 import Control.Monad.Except.Trans (ExceptT)
 import Data.Foreign (Foreign, F, ForeignError(..), typeOf, isUndefined, isNull, fail)
 import Data.Function.Uncurried (Fn2, runFn2, Fn4, runFn4)

--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -7,6 +7,7 @@ module Data.Foreign.Index
   , readProp
   , readProp'
   , readIndex
+  , readIndex'
   , ix, (!)
   , index
   , hasProperty
@@ -43,12 +44,12 @@ unsafeReadProp k value =
   runFn4 unsafeReadPropImpl (fail (TypeMismatch "object" (typeOf value))) pure k value
 
 -- | Attempt to read a value from a foreign value property,
--- | failing if the value is null
+-- | failing if the foreign value is null
 readProp :: String -> Foreign -> F Foreign
 readProp = unsafeReadProp
 
 -- | Attempt to read a value from a foreign value property,
--- | failing if the value is null, or the property does not
+-- | failing if the foreign value is null, or the property does not
 -- | exist
 readProp' :: String -> Foreign -> F Foreign
 readProp' s f = do
@@ -58,11 +59,24 @@ readProp' s f = do
       p <- readProp s f
       case hasProperty s f of
         true -> pure p
-        false -> fail $ ForeignError $ "Error reading non-existant property '" <> s <> "'."
+        false -> fail $ ForeignError $ "Error reading non-existent property '" <> s <> "'."
 
 -- | Attempt to read a value from a foreign value at the specified numeric index
 readIndex :: Int -> Foreign -> F Foreign
 readIndex = unsafeReadProp
+
+-- | Attempt to read a value from a foreign value at the specified numeric index,
+-- | failing if the foreign value is null, or the index does not
+-- | exist
+readIndex' :: Int -> Foreign -> F Foreign
+readIndex' s f = do
+  case isNull f of
+    true -> fail $ ForeignError $ "Error reading index " <> (show s) <> " from null value."
+    false -> do
+      p <- readIndex s f
+      case hasProperty s f of
+        true -> pure p
+        false -> fail $ ForeignError $ "Error reading non-existent index " <> (show s)
 
 foreign import unsafeHasOwnProperty :: forall k. Fn2 k Foreign Boolean
 

--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -14,9 +14,11 @@ module Data.Foreign.Index
   ) where
 
 import Prelude
+
 import Control.Monad.Except.Trans (ExceptT)
-import Data.Foreign (F, Foreign, ForeignError(..), fail, isNull, isUndefined, typeOf)
-import Data.Function.Uncurried (Fn2, Fn5, runFn2, runFn5)
+
+import Data.Foreign (Foreign, F, ForeignError(..), typeOf, isUndefined, isNull, fail)
+import Data.Function.Uncurried (Fn2, runFn2, Fn4, runFn4)
 import Data.Identity (Identity)
 import Data.List.NonEmpty (NonEmptyList)
 
@@ -34,21 +36,11 @@ class Indexable a where
 
 infixl 9 ix as !
 
-foreign import unsafeReadPropImpl :: forall r k. Fn5 r r (Foreign -> r) k Foreign r
+foreign import unsafeReadPropImpl :: forall r k. Fn4 r (Foreign -> r) k Foreign r
 
-unsafeReadProp :: String -> Foreign -> F Foreign
+unsafeReadProp :: forall k. k -> Foreign -> F Foreign
 unsafeReadProp k value =
-  runFn5 unsafeReadPropImpl
-    (fail (TypeMismatch "object" (typeOf value)))
-    (fail (ForeignError $ "Error reading non-existant property '" <> k <> "'"))
-    pure k value
-
-unsafeReadIndex :: Int -> Foreign -> F Foreign
-unsafeReadIndex k value =
-  runFn5 unsafeReadPropImpl
-    (fail (TypeMismatch "object" (typeOf value)))
-    (fail (ForeignError $ "Error reading non-existant index " <> (show k)))
-    pure k value
+  runFn4 unsafeReadPropImpl (fail (TypeMismatch "object" (typeOf value))) pure k value
 
 -- | Attempt to read a value from a foreign value property
 readProp :: String -> Foreign -> F Foreign
@@ -56,7 +48,7 @@ readProp = unsafeReadProp
 
 -- | Attempt to read a value from a foreign value at the specified numeric index
 readIndex :: Int -> Foreign -> F Foreign
-readIndex = unsafeReadIndex
+readIndex = unsafeReadProp
 
 foreign import unsafeHasOwnProperty :: forall k. Fn2 k Foreign Boolean
 

--- a/src/Data/Foreign/Index.purs
+++ b/src/Data/Foreign/Index.purs
@@ -14,11 +14,9 @@ module Data.Foreign.Index
   ) where
 
 import Prelude
-
 import Control.Monad.Except.Trans (ExceptT)
-
-import Data.Foreign (Foreign, F, ForeignError(..), typeOf, isUndefined, isNull, fail)
-import Data.Function.Uncurried (Fn2, runFn2, Fn4, runFn4)
+import Data.Foreign (F, Foreign, ForeignError(..), fail, isNull, isUndefined, typeOf)
+import Data.Function.Uncurried (Fn2, Fn5, runFn2, runFn5)
 import Data.Identity (Identity)
 import Data.List.NonEmpty (NonEmptyList)
 
@@ -36,11 +34,21 @@ class Indexable a where
 
 infixl 9 ix as !
 
-foreign import unsafeReadPropImpl :: forall r k. Fn4 r (Foreign -> r) k Foreign r
+foreign import unsafeReadPropImpl :: forall r k. Fn5 r r (Foreign -> r) k Foreign r
 
-unsafeReadProp :: forall k. k -> Foreign -> F Foreign
+unsafeReadProp :: String -> Foreign -> F Foreign
 unsafeReadProp k value =
-  runFn4 unsafeReadPropImpl (fail (TypeMismatch "object" (typeOf value))) pure k value
+  runFn5 unsafeReadPropImpl
+    (fail (TypeMismatch "object" (typeOf value)))
+    (fail (ForeignError $ "Error reading non-existant property '" <> k <> "'"))
+    pure k value
+
+unsafeReadIndex :: Int -> Foreign -> F Foreign
+unsafeReadIndex k value =
+  runFn5 unsafeReadPropImpl
+    (fail (TypeMismatch "object" (typeOf value)))
+    (fail (ForeignError $ "Error reading non-existant index " <> (show k)))
+    pure k value
 
 -- | Attempt to read a value from a foreign value property
 readProp :: String -> Foreign -> F Foreign
@@ -48,7 +56,7 @@ readProp = unsafeReadProp
 
 -- | Attempt to read a value from a foreign value at the specified numeric index
 readIndex :: Int -> Foreign -> F Foreign
-readIndex = unsafeReadProp
+readIndex = unsafeReadIndex
 
 foreign import unsafeHasOwnProperty :: forall k. Fn2 k Foreign Boolean
 


### PR DESCRIPTION
Would it be ok to replaced `unsafeReadProp` in Data.Foreign.Index with something like this that distinguishes between "this is not an object" error and "the property could not be found" error?

```purescript
foreign import unsafeReadPropImpl :: forall r k. Fn5 r r (Foreign -> r) k Foreign r

unsafeReadProp :: String -> Foreign -> F Foreign
unsafeReadProp k value =
  runFn5 unsafeReadPropImpl
    (fail (TypeMismatch "object" (typeOf value)))
    (fail (ForeignError $ "Error reading non-existant property '" <> k <> "'"))
    pure k value

unsafeReadIndex :: Int -> Foreign -> F Foreign
unsafeReadIndex k value =
  runFn5 unsafeReadPropImpl
    (fail (TypeMismatch "object" (typeOf value)))
    (fail (ForeignError $ "Error reading non-existant index " <> (show k)))
    pure k value
```

```javascript
exports.unsafeReadPropImpl = function (f, f2, s, key, value) {
  if (value == null) {
    // Fail with "not an object error"
    return f;
  } else {
    if (key in value) {
      return s(value[key]);
    } else {
      // Fail with "property does not
      // exist or index does not exist"
      return f2;
    }
  };
};
```

I think that might make the error messages a little nicer. Here's workable example to further illustrate...

```purescript
data SomeData = SomeData { paths :: Array String }

readSomeData :: Foreign -> F SomeData
readSomeData f = do
  possiblyPath <- (readProp "paths" f) <|> (fail $ ForeignError ". The 'paths' property does not exist.")
  possiblyArray <- readArray possiblyPath <|> (fail $ ForeignError ". The 'paths' property is not an array.")
  paths <- traverse readString possiblyArray
  pure $ SomeData { paths }
```

Right now if try and encode `{ "somebadkey" : [] }` it will error with "Type mismatch: expected array, found Undefined. The 'paths' property is not an array." So it seems to bypass the "I can't find that path" error when running `readProp "paths" f`.

Also, side question, if try and encode `{ "paths : "a" }` I get the error "Type mismatch: expected array, found String. The 'paths' property is not an array." Is there a way for the caller of readArray to override the error message set in the core library? Ideally, I'd like to only have the error "The 'paths' property is not an array" so the user has a more focused error message.