### PR TITLE
Provide an example of using Newtype and Maybe Newtype

### DIFF
--- a/examples/Newtypes.purs
+++ b/examples/Newtypes.purs
@@ -1,0 +1,37 @@
+module Example.Newtypes where
+
+import Prelude
+import Control.Monad.Except (runExcept)
+import Data.Maybe (Maybe)
+import Data.Traversable (traverse)
+import Effect (Effect)
+import Effect.Console (logShow)
+import Example.Util.Value (foreignValue)
+import Foreign (F, Foreign, readNullOrUndefined, readString)
+import Foreign.Index ((!))
+
+newtype Email
+  = Email String
+
+derive newtype instance showEmail :: Show Email
+
+type SomeObject
+  = { foo :: String
+    , bar :: Maybe String
+    , baz :: Email
+    , duh :: Maybe Email
+    }
+
+readObject :: Foreign -> F SomeObject
+readObject value = do
+  foo <- value ! "foo" >>= readString
+  bar <- value ! "bar" >>= readNullOrUndefined >>= traverse readString
+  baz <- value ! "baz" >>= readString <#> Email
+  duh <- value ! "duh" >>= readNullOrUndefined >>= traverse readString <#> map Email
+  pure { foo, bar, baz, duh }
+
+main :: Effect Unit
+main = do
+  logShow $ runExcept
+    $ readObject
+    =<< foreignValue """{ "foo": "a@b.org", "bar": null, "baz": "c@d.net" }"""


### PR DESCRIPTION
This pull request adds an example of using Newtype as well as Maybe Newtype.

Being relatively new to PureScript, it took me a bit of time to understand what was going on with the nested Except and Maybe functors. The journey taught me a lot however and I believe this example could be helpful to others.

I feel there's something not really idiomatic in using `<#> map Email`, which initially came up as `<#> (<$>) Email` while I was figuring out the types and nesting.

I'd happily rename `Email` and `foo`, `bar`, `baz`, `duh` to something more meaningful.