### PR TITLE
fix: readArray function -> `TypeMismatch "array"` should be `TypeMism…

### DIFF
--- a/src/Foreign.purs
+++ b/src/Foreign.purs
@@ -149,7 +149,7 @@ readInt value = mapExcept (either (const error) fromNumber) (readNumber value)
 readArray :: Foreign -> F (Array Foreign)
 readArray value
   | isArray value = pure $ unsafeFromForeign value
-  | otherwise = fail $ TypeMismatch "array" (tagOf value)
+  | otherwise = fail $ TypeMismatch "Array" (tagOf value)
 
 readNull :: Foreign -> F (Maybe Foreign)
 readNull value


### PR DESCRIPTION
…atch "Array"` because all other error messages start with capital letter